### PR TITLE
Add missing attributes to global stylesheet url

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -167,7 +167,7 @@
             <p>The patterns in this repository are organized as <em>Elements</em>, <em>Components</em> (coming soon), and <em>Objects</em> for styling pages with the NYC Opportunity brand. The can be dropped into any web page on linking to the global stylesheet
               url in the head of an html page;</p>
             <p>
-              <div class="code-block"><pre><div>&lt;link href=&quot;https://cdn.jsdelivr.net/gh/CityOfNewYork/nyco-patterns@v1.7.0/dist/styles/nyco-patterns-default.css&quot;&gt;</div></pre></div>
+              <div class="code-block"><pre><div>&lt;link href=&quot;https://cdn.jsdelivr.net/gh/CityOfNewYork/nyco-patterns@v1.7.0/dist/styles/nyco-patterns-default.css rel=&quot;stylesheet&quot; type=&quot;text/css&quot;&gt;</div></pre></div>
             </p>
             <p>This distribution includes a custom build of the
               <a href='https://tailwindcss.com'>Tailwind Utility CSS Framework</a>. Refer to Tailwind CSS docs for full details on utilizing the CSS uitilites to build different types of UIs.</p>

--- a/src/views/index.slm
+++ b/src/views/index.slm
@@ -38,7 +38,7 @@
           div class='code-block'
             pre
               div
-                = '<link href="' + link_stylesheet + '">';
+                = '<link href="' + link_stylesheet + ' rel="stylesheet" type="text/css">'
 
         p
           | This distribution includes a custom build of the <a href='${link_tailwind_docs}'>Tailwind Utility CSS Framework</a>. Refer to Tailwind CSS docs for full details on utilizing the CSS uitilites to build different types of UIs.


### PR DESCRIPTION
Integrating NYCO patterns via the CDN method wouldn't work
because URL was missing rel and type attributes.