### PR TITLE
Add closing script tags to Feed view

### DIFF
--- a/dist/feed.html
+++ b/dist/feed.html
@@ -176,7 +176,7 @@
             </h2>
             <p>To use the feed, include the following scripts in your page:</p>
             <p>
-              <div class="code-block"><pre><div>&lt;script src=&quot;https://cdn.polyfill.io/v2/polyfill.js?features=Promise&amp;gated=gated&quot; type=&quot;text/javascript&quot;&gt; <span class="code__comment">&lt;!-- The feed component uses Promises so this polyfill is needed for IE support --&gt;</span></div><div>&lt;script src=&quot;https://cdn.jsdelivr.net/gh/CityOfNewYork/nyco-patterns@v1.7.0/dist/objects/feed/Feed.js&quot; type=&quot;text/javascript&quot;&gt;</div></pre></div>
+              <div class="code-block"><pre><div>&lt;script src=&quot;https://cdn.polyfill.io/v2/polyfill.js?features=Promise&amp;gated=gated&quot; type=&quot;text/javascript&quot;&gt;&lt;/script&gt; <span class="code__comment">&lt;!-- The feed component uses Promises so this polyfill is needed for IE support --&gt;</span></div><div>&lt;script src=&quot;https://cdn.jsdelivr.net/gh/CityOfNewYork/nyco-patterns@v1.7.0/dist/objects/feed/Feed.js&quot; type=&quot;text/javascript&quot;&gt;&lt;/script&gt;</div></pre></div>
             </p>
             <p>Optionally, but recommended, include the base styling for the feed:</p>
             <p>

--- a/src/views/feed.slm
+++ b/src/views/feed.slm
@@ -47,9 +47,10 @@
           div class='code-block'
             pre
               div
-                = '<script src="https://cdn.polyfill.io/v2/polyfill.js?features=Promise&gated=gated" type="text/javascript"> ';
+                = '<script src="https://cdn.polyfill.io/v2/polyfill.js?features=Promise&gated=gated" type="text/javascript"></script> ';
                 span class='code__comment' = '<!-- The feed component uses Promises so this polyfill is needed for IE support -->';
-              div = '<script src="' + this.site.urls.cdn + '/objects/feed/Feed.js" type="text/javascript">';
+              div
+                = '<script src="' + this.site.urls.cdn + '/objects/feed/Feed.js" type="text/javascript"></script>';
 
         p
           | Optionally, but recommended, include the base styling for the feed:
@@ -57,7 +58,8 @@
         p
           div class='code-block'
             pre
-              div = '<link src="' + this.site.urls.cdn + '/objects/feed/feed.css" rel="stylesheet" type="text/css" media="screen">';
+              div
+                = '<link src="' + this.site.urls.cdn + '/objects/feed/feed.css" rel="stylesheet" type="text/css" media="screen">';
 
         p
           | Then, add a container with the feed's id and the execution script with configuration parameters.


### PR DESCRIPTION
In the documentation for adding the Feed component via script tags an
error will occur because it was missing `</script>` a closing script
tag.